### PR TITLE
Make an optional eagerloading

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mono_repo_deps (0.1.14)
+    mono_repo_deps (0.2.0)
       dry-auto_inject (~> 1.0.1)
       dry-configurable (~> 1.0.1)
       dry-container (~> 0.11.0)

--- a/example/bounded_contexts/cart/cart_core/Package.rb
+++ b/example/bounded_contexts/cart/cart_core/Package.rb
@@ -4,7 +4,7 @@ end
 
 dependency do
   import 'cart_datasets'
-  import 'orders_query_api', only: ['orders_datasets']
+  import 'orders_query_api'
 end
 
 dependency :test do

--- a/lib/mono_repo_deps.rb
+++ b/lib/mono_repo_deps.rb
@@ -84,34 +84,6 @@ module MonoRepoDeps
       end
     end
 
-    def check_classes(from = caller_locations.first.path)
-      # sync_current_project!(from) do
-      #   all_packages = Container["package.repo"].all
-      #   total_count = all_packages.size
-      #   imported = []
-      #   packages_order = []
-
-      #   all_packages.each_with_index do |package, idx|
-      #     puts "loading package #{package.name} (#{idx+1}/#{total_count}/#{imported.size})"
-
-      #     Container["package.dependency_bypasser"].call(
-      #       package_name: package.name,
-      #       imported: imported,
-      #       packages_order: packages_order,
-      #       env: current_project.env
-      #     )
-      #   end
-
-      #   packages_order
-      #     .uniq
-      #     .map { Container["package.repo"].find(_1) }
-      #     .each { current_project.loader.push_dir(_1.workdir_path) }
-      #     .tap { current_project.loader.setup }
-      #     .each { require _1.entrypoint_file if File.exist?(_1.entrypoint_file) }
-      #     .tap { current_project.loader.check_classes }
-      # end
-    end
-
     def sync_current_project!(path, &block)
       path = File.expand_path(path)
       path = File.dirname(path) unless File.directory?(path)

--- a/lib/mono_repo_deps.rb
+++ b/lib/mono_repo_deps.rb
@@ -45,12 +45,12 @@ module MonoRepoDeps
   class << self
     attr_accessor :current_project
 
-    def init_package(package_name = nil, from: caller_locations.first.path, env: nil)
+    def init_package(package_name = nil, from: caller_locations.first.path, env: nil, prevent_eager_load: false)
       sync_current_project!(from) do
         package_name ||= Container["package.builder"].call(from, current_project.root_path, current_project.package_dirname).name
         env ||= current_project.env
 
-        Container["package.initializer"].call(package_name, env: env)
+        Container["package.initializer"].call(package_name, env: env, prevent_eager_load: prevent_eager_load)
       end
     end
 

--- a/lib/mono_repo_deps.rb
+++ b/lib/mono_repo_deps.rb
@@ -85,31 +85,31 @@ module MonoRepoDeps
     end
 
     def check_classes(from = caller_locations.first.path)
-      sync_current_project!(from) do
-        all_packages = Container["package.repo"].all
-        total_count = all_packages.size
-        imported = []
-        packages_order = []
+      # sync_current_project!(from) do
+      #   all_packages = Container["package.repo"].all
+      #   total_count = all_packages.size
+      #   imported = []
+      #   packages_order = []
 
-        all_packages.each_with_index do |package, idx|
-          puts "loading package #{package.name} (#{idx+1}/#{total_count}/#{imported.size})"
+      #   all_packages.each_with_index do |package, idx|
+      #     puts "loading package #{package.name} (#{idx+1}/#{total_count}/#{imported.size})"
 
-          Container["package.dependency_bypasser"].call(
-            package_name: package.name,
-            imported: imported,
-            packages_order: packages_order,
-            env: current_project.env
-          )
-        end
+      #     Container["package.dependency_bypasser"].call(
+      #       package_name: package.name,
+      #       imported: imported,
+      #       packages_order: packages_order,
+      #       env: current_project.env
+      #     )
+      #   end
 
-        packages_order
-          .uniq
-          .map { Container["package.repo"].find(_1) }
-          .each { current_project.loader.push_dir(_1.workdir_path) }
-          .tap { current_project.loader.setup }
-          .each { require _1.entrypoint_file if File.exist?(_1.entrypoint_file) }
-          .tap { current_project.loader.check_classes }
-      end
+      #   packages_order
+      #     .uniq
+      #     .map { Container["package.repo"].find(_1) }
+      #     .each { current_project.loader.push_dir(_1.workdir_path) }
+      #     .tap { current_project.loader.setup }
+      #     .each { require _1.entrypoint_file if File.exist?(_1.entrypoint_file) }
+      #     .tap { current_project.loader.check_classes }
+      # end
     end
 
     def sync_current_project!(path, &block)

--- a/lib/mono_repo_deps/package.rb
+++ b/lib/mono_repo_deps/package.rb
@@ -5,14 +5,12 @@ class MonoRepoDeps::Package
 
   DEFAULT_ENV = :_default_
 
-  DependencyDto = Struct.new(:name, :only, :skip, keyword_init: true)
-
   sig do
     params(
       name: Symbol,
       root_path: String,
       package_dirname: String,
-      dependencies: T::Hash[Symbol, DependencyDto]
+      dependencies: T::Hash[Symbol, Symbol]
     )
     .void
   end
@@ -26,12 +24,18 @@ class MonoRepoDeps::Package
   end
 
   sig do
-    params(env: T.nilable(Symbol)).returns(T::Array[DependencyDto])
+    params(env: T.nilable(Symbol)).returns(T::Array[Symbol])
   end
   def get_dependencies(env = nil)
-    [DEFAULT_ENV, env].uniq.compact.inject([]) do |acc, item|
-      acc += @dependencies.fetch(item, [])
-    end
+    default_deps = @dependencies.fetch(DEFAULT_ENV, [])
+    env_deps     = @dependencies.fetch(env, [])
+
+    default_deps | env_deps
+  end
+
+  def get_bc
+    # /app/bounded_contexts/jobs/microservices/jobs_app
+    @root_path.split('/')[3]
   end
 
   def get_dependency_envs

--- a/lib/mono_repo_deps/package/dependency_bypasser.rb
+++ b/lib/mono_repo_deps/package/dependency_bypasser.rb
@@ -17,9 +17,7 @@ class MonoRepoDeps::Package::DependencyBypasser
     .returns(T::Array[Symbol])
   end
   def call(package_name:, env:)
-    imported = Set.new
-
-    walk(package_name: package_name, env: env, imported: imported)
+    walk(package_name: package_name, env: env, imported: Set.new)
   end
 
   private

--- a/lib/mono_repo_deps/package/factory.rb
+++ b/lib/mono_repo_deps/package/factory.rb
@@ -30,7 +30,6 @@ class MonoRepoDeps::Package::Factory
     package.get_dependency_envs.each do |env|
       already_imported = package
         .get_dependencies(env)
-        .map(&:name)
         .group_by{ |e| e }
         .select { |k, v| v.size > 1 }
         .keys
@@ -59,17 +58,13 @@ class MonoRepoDeps::Package::Factory
   sig do
     params(
       package_name: T.any(Symbol, String),
-      skip: T.nilable(T::Array[Symbol]),
-      only: T.nilable(T::Array[Symbol]),
     )
     .void
   end
-  def import(package_name, skip: nil, only: nil)
+  def import(package_name)
     package_name = package_name.to_sym
-    skip = skip&.map(&:to_sym)
-    only = only&.map(&:to_sym)
 
-    @dependencies[@current_env] << MonoRepoDeps::Package::DependencyDto.new(name: package_name, skip: skip, only: only)
+    @dependencies[@current_env] << package_name
 
     nil
   end

--- a/lib/mono_repo_deps/package/initializer.rb
+++ b/lib/mono_repo_deps/package/initializer.rb
@@ -14,24 +14,31 @@ class MonoRepoDeps::Package::Initializer
     params(
       package_name: T.any(Symbol, String),
       env: Symbol,
-      imported: T::Array[Symbol]
     )
     .void
   end
-  def call(package_name, env:, imported: [])
-    package_name = package_name.to_sym
-    packages_import_order = []
+  def call(package_name, env:)
+    package = repo.find!(package_name.to_sym)
+    sorted_packages = nil
 
     time = Benchmark.realtime do
-      packages_import_order = dependency_bypasser
-        .call(package_name: package_name, env: env, imported: imported)
-        .map { repo.find(_1) }
-        .each { MonoRepoDeps.current_project.loader.push_dir(_1.workdir_path) }
-        .tap { MonoRepoDeps.current_project.loader.setup }
-        .each { |package| require package.entrypoint_file if File.exist?(package.entrypoint_file) }
+      sorted_packages = dependency_bypasser
+        .call(package_name: package.name, env: env)
+        .map { |name| repo.find(name) }
+
+      sorted_packages.each do |sorted_package|
+        MonoRepoDeps.current_project.loader.push_dir(sorted_package.workdir_path)
+        MonoRepoDeps.current_project.loader.loader.do_not_eager_load(sorted_package.workdir_path)
+      end
+
+      MonoRepoDeps.current_project.loader.setup
+
+      sorted_packages.each do |package|
+        require package.entrypoint_file if File.exist?(package.entrypoint_file)
+      end
     end
 
-    puts "imported package '#{package_name}' with #{packages_import_order.size} dependencies in #{'%.2f' % time} seconds for env: #{env}"
+    puts "imported package '#{package_name}' with #{sorted_packages.size} dependencies in #{'%.2f' % time} seconds for env: #{env}"
 
     nil
   end

--- a/lib/mono_repo_deps/package/initializer.rb
+++ b/lib/mono_repo_deps/package/initializer.rb
@@ -14,10 +14,11 @@ class MonoRepoDeps::Package::Initializer
     params(
       package_name: T.any(Symbol, String),
       env: Symbol,
+      prevent_eager_load: T::Boolean
     )
     .void
   end
-  def call(package_name, env:)
+  def call(package_name, env:, prevent_eager_load: false)
     package = repo.find!(package_name.to_sym)
     sorted_packages = nil
 
@@ -28,7 +29,7 @@ class MonoRepoDeps::Package::Initializer
 
       sorted_packages.each do |sorted_package|
         MonoRepoDeps.current_project.loader.push_dir(sorted_package.workdir_path)
-        MonoRepoDeps.current_project.loader.loader.do_not_eager_load(sorted_package.workdir_path)
+        MonoRepoDeps.current_project.loader.loader.do_not_eager_load(sorted_package.workdir_path) if prevent_eager_load
       end
 
       MonoRepoDeps.current_project.loader.setup

--- a/lib/mono_repo_deps/version.rb
+++ b/lib/mono_repo_deps/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MonoRepoDeps
-  VERSION = "0.1.14"
+  VERSION = "0.2.0"
 end

--- a/spec/mono_repo_deps/package/builder_spec.rb
+++ b/spec/mono_repo_deps/package/builder_spec.rb
@@ -10,13 +10,8 @@ RSpec.describe MonoRepoDeps::Package::Builder do
     expect(package.name).to eq(:orders_app)
 
     expect(package.dependencies).to eq({
-      _default_: [
-        MonoRepoDeps::Package::DependencyDto.new(name: :orders_core)
-      ],
-      test: [
-        MonoRepoDeps::Package::DependencyDto.new(name: :test_utils),
-        MonoRepoDeps::Package::DependencyDto.new(name: :storefront_core)
-      ]
+      _default_: [:orders_core],
+      test: [:test_utils, :storefront_core]
     })
   end
 end

--- a/spec/mono_repo_deps/package/dependency_bypasser_spec.rb
+++ b/spec/mono_repo_deps/package/dependency_bypasser_spec.rb
@@ -12,8 +12,8 @@ RSpec.describe MonoRepoDeps::Package::DependencyBypasser do
     let(:packages_list) {
       Proc.new do
         [
-          SpecHelper.build_package(name: :package_1, deps: [{name: :package_2, only: []}]),
-          SpecHelper.build_package(name: :package_2, deps: [{name: :package_3}]),
+          SpecHelper.build_package(name: :package_1, deps: [:package_2]),
+          SpecHelper.build_package(name: :package_2, deps: [:package_3]),
           SpecHelper.build_package(name: :package_3, deps: []),
         ]
       end
@@ -22,7 +22,7 @@ RSpec.describe MonoRepoDeps::Package::DependencyBypasser do
     it {
       expect(
         subject.call( package_name: :package_1, env: :production )
-      ).to match([:package_2, :package_1])
+      ).to match([:package_3, :package_2, :package_1])
     }
   end
 
@@ -30,9 +30,9 @@ RSpec.describe MonoRepoDeps::Package::DependencyBypasser do
     let(:packages_list) {
       Proc.new do
         [
-          SpecHelper.build_package(name: :package_1, deps: [{name: :package_4}, {name: :package_2}, {name: :package_3}]),
-          SpecHelper.build_package(name: :package_2, deps: [{name: :package_3}, {name: :package_4}]),
-          SpecHelper.build_package(name: :package_3, deps: [{name: :package_4}]),
+          SpecHelper.build_package(name: :package_1, deps: [:package_4, :package_2, :package_3]),
+          SpecHelper.build_package(name: :package_2, deps: [:package_3, :package_4]),
+          SpecHelper.build_package(name: :package_3, deps: [:package_4]),
           SpecHelper.build_package(name: :package_4, deps: []),
         ]
       end

--- a/spec/mono_repo_deps/package/factory_spec.rb
+++ b/spec/mono_repo_deps/package/factory_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe MonoRepoDeps::Package::Factory do
 
       dependency do
         import 'package_1'
-        import 'package_2', only: [:package_2_1]
-        import 'package_3', skip: [:package_3_1]
+        import 'package_2'
+        import 'package_3'
       end
 
       dependency :test do
@@ -23,12 +23,12 @@ RSpec.describe MonoRepoDeps::Package::Factory do
     expect(package.name).to eq(:package_0)
     expect(package.dependencies).to match({
       _default_: [
-        MonoRepoDeps::Package::DependencyDto.new(name: :package_1, only: nil, skip: nil),
-        MonoRepoDeps::Package::DependencyDto.new(name: :package_2, only: [:package_2_1], skip: nil),
-        MonoRepoDeps::Package::DependencyDto.new(name: :package_3, only: nil, skip: [:package_3_1])
+        :package_1,
+        :package_2,
+        :package_3
       ],
       test: [
-        MonoRepoDeps::Package::DependencyDto.new(name: :package_4, only: nil, skip: nil)
+        :package_4
       ]
     })
   end

--- a/spec/mono_repo_deps/package/initializer_spec.rb
+++ b/spec/mono_repo_deps/package/initializer_spec.rb
@@ -3,7 +3,7 @@ RSpec.describe MonoRepoDeps::Package::Initializer do
     expect(Object.const_defined?(:OrdersApp)).to be false
 
     MonoRepoDeps.sync_current_project!(SpecHelper.examples_dir) do
-      subject.call('orders_app', env: :test)
+      subject.call('orders_app', env: :test, prevent_eager_load: true)
     end
 
     expect(Object.const_defined?(:OrdersApp)).to be true

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,7 +26,7 @@ module SpecHelper
         root_path: 'test',
         package_dirname: 'package',
         dependencies: {
-          MonoRepoDeps::Package::DEFAULT_ENV => deps.map { MonoRepoDeps::Package::DependencyDto.new(_1) }
+          MonoRepoDeps::Package::DEFAULT_ENV => deps
         }
       )
     end


### PR DESCRIPTION
changelog
- remove [only:, skip:] options for package imports
- add optional prevent_eager_load: parameter to prevent Zeitwerk eager_load for package directory
- refactor Package and make it's dependencies as symbols instead of Dto objects
- refactor DependencyBypasser and prepare to not to forward env for recursive deps lookups